### PR TITLE
Fix the checkpoint issues with tags

### DIFF
--- a/packages/wasmkit/src/lib/deploy/contract.ts
+++ b/packages/wasmkit/src/lib/deploy/contract.ts
@@ -21,7 +21,11 @@ import type {
   WasmkitRuntimeEnvironment
 } from "../../types";
 import { loadCheckpoint, persistCheckpoint } from "../checkpoints";
-import { executeTransaction, getClient, getSigningClient, instantiateContract, sendQuery, storeCode } from "../client";
+import {
+  executeTransaction, getClient, getSigningClient,
+  instantiateContract, sendQuery,
+  storeCode
+} from "../client";
 
 export interface ExecArgs {
   account: Account | UserAccount


### PR DESCRIPTION
1. Playground creation now parsing multiple instance of same codeId
2. When doing multiple instance deploy in same script, it now recognises and updates checkpoints at each deploy and init